### PR TITLE
Add type declaration files to non-CLI packages

### DIFF
--- a/packages/cowlog/package.json
+++ b/packages/cowlog/package.json
@@ -16,6 +16,7 @@
     "url": "https://github.com/vidaxl-com/cowlog/issues"
   },
   "main": "dist/src/index.js",
+  "types": "src/index.d.ts",
   "scripts": {
     "test-dev": "node_modules/.bin/mocha --recursive tests/tests ",
     "test-dev-unit": "npm run clean && node_modules/.bin/mocha --recursive tests/tests/unit",

--- a/packages/cowlog/src/index.d.ts
+++ b/packages/cowlog/src/index.d.ts
@@ -1,0 +1,79 @@
+declare module 'cowlog' {
+  class Jimple {
+    /**
+     * Create a Jimple Container.
+     * @param [values] - An optional object whose keys and values will be associated in the container at initialization
+     */
+    constructor(values?: object);
+
+    static provider(register: any): object;
+
+    /**
+     * Return the specified parameter or service. If the service is not built yet, this function will construct the service
+     * injecting all the dependencies needed in it's definition so the returned object is totally usable on the fly.
+     * @param key - The key of the parameter or service to return
+     * @return The object related to the service or the value of the parameter associated with the key informed
+     * @throws If the key does not exist
+     */
+    get(key: string): any;
+
+    /**
+     * Defines a new parameter or service.
+     * @param key - The key of the parameter or service to be defined
+     * @param value - The value of the parameter or a function that receives the container as parameter and constructs the service
+     */
+    set(key: string, value: any): void;
+
+    /**
+     * Returns if a service or parameter with the informed key is already defined in the container.
+     * @param key - The key of the parameter or service to be checked.
+     * @return If the key exists in the container or not
+     */
+    has(key: string): boolean;
+
+    /**
+     * Defines a service as a factory, so the instances are not cached in the service and that function is always called
+     * @param fn - The function that constructs the service that is a factory
+     * @return The same function passed as parameter
+     */
+    factory<T extends Function>(fn: T): T;
+
+    /**
+     * Defines a function as a parameter, so that function is not considered a service
+     * @param fn - The function to not be considered a service
+     * @return The same function passed as parameter
+     */
+    protect<T extends Function>(fn: T): T;
+
+    /**
+     * Return all the keys registered in the container
+     */
+    keys(): string[];
+
+    /**
+     * Extends a service already registered in the container
+     * @param key - The key of the service to be extended
+     * @param fn - The function that will be used to extend the service
+     * @throws If the key is not already defined
+     * @throws If the key saved in the container does not correspond to a service
+     * @throws If the function passed it not...well, a function
+     */
+    extend(key: string, fn: Function): void;
+
+    /**
+     * Uses an provider to extend the service, so it's easy to split the service and parameter definitions across the system
+     * @param provider - The provider to be used to register services and parameters in this container
+     */
+    register(provider: { register: Function}): void;
+
+    /**
+     * Returns the raw value of a service or parameter. So, in the case of a service, for example, the value returned is the
+     * function used to construct the service.
+     * @param key - The key of the service or parameter to return.
+     * @throws If the key does not exist in the container
+     * @return The raw value of the service or parameter
+     */
+    raw(key: string): any;
+  }
+  export default function l(...params: any): Jimple;
+}

--- a/packages/directory-fixture-provider/package.json
+++ b/packages/directory-fixture-provider/package.json
@@ -3,6 +3,7 @@
   "version": "1.6.62",
   "description": "Provides directories for testing.",
   "main": "dist/src/index.js",
+  "types": "src/index.d.ts",
   "scripts": {
     "test-dev": "node_modules/.bin/mocha --recursive tests/tests",
     "test-dev-unit": "npm run clean && node_modules/.bin/mocha --recursive tests/tests/unit",

--- a/packages/directory-fixture-provider/src/index.d.ts
+++ b/packages/directory-fixture-provider/src/index.d.ts
@@ -1,0 +1,26 @@
+declare module 'directory-fixture-provider' {
+  export default function dfp(location: string): () => {
+    get(fixtureDirectory: string): {
+      dir: string;
+      fixturePath: string;
+      getFixtureFiles: () => object;
+      getDestinationFiles: () => object;
+      getStatus: () => {
+        paths: {
+          destination: string;
+          fixtures: string;
+        };
+        changeList: object;
+        changeNumbers: {
+          deleted: number;
+          changed: number;
+          new: number;
+        };
+        changeTotals: number;
+        contents: any;
+        changed: boolean;        
+      };
+      getFixtureContent: (fixturesRoot: string, fixturesDirectory: string) => any;
+    }
+  };
+}

--- a/packages/dsl-framework/package.json
+++ b/packages/dsl-framework/package.json
@@ -3,6 +3,7 @@
   "version": "1.6.62",
   "description": "Easy function chaining.",
   "main": "src/index.js",
+  "types": "src/index.d.ts",
   "scripts": {
     "test-dev": "node_modules/.bin/mocha --recursive tests/tests/node/*-spec.js",
     "test-dev-unit": "npm run clean && node_modules/.bin/mocha --recursive tests/tests/node/unit/*-spec.js",

--- a/packages/dsl-framework/src/index.d.ts
+++ b/packages/dsl-framework/src/index.d.ts
@@ -1,0 +1,3 @@
+declare module 'dsl-framework' {
+  export default function unlimitedCurry(callback: (e: any, parameters: object) => any, paramManipulator: (parameters: object) => string): typeof unlimitedCurry | Promise<typeof unlimitedCurry>;
+}

--- a/packages/generic-text-linker/package.json
+++ b/packages/generic-text-linker/package.json
@@ -3,6 +3,7 @@
   "version": "1.6.62",
   "description": "Generic text linker for NodeJs",
   "main": "dist/src/index.js",
+  "types": "src/index.d.ts",
   "scripts": {
     "depcheck": "^0.6.11",
     "test-dev": "node_modules/.bin/mocha --recursive tests/tests",

--- a/packages/generic-text-linker/src/index.d.ts
+++ b/packages/generic-text-linker/src/index.d.ts
@@ -1,0 +1,11 @@
+declare module 'generic-text-linker' {
+  type MetaObject = {
+    returnData: string;
+    meta: object;
+  }
+  export function linker(inputString: string, beginning: number, closing: number, newValue?: string): MetaObject;
+  export function linkerDir(dir: string[], beginning: number, closing: number, newValue?: string): string;
+  export function linkerFile(file: string, beginning: number, closing: number, newValue?: string): MetaObject;
+  export function substingToLineMapper(input: string, find: string): number[];
+  export function fileProvider(rootDir: string): string[];
+}

--- a/packages/require-a-lot/package.json
+++ b/packages/require-a-lot/package.json
@@ -3,6 +3,7 @@
   "version": "1.6.65",
   "description": "Require more dependencies elegantly.",
   "main": "src/index.js",
+  "types": "src/index.d.ts",
   "scripts": {
     "test-dev": "node_modules/.bin/mocha --recursive tests/tests/*-spec.js",
     "test-dev-unit": "npm run clean && node_modules/.bin/mocha --recursive tests/tests/unit/*-spec.js",

--- a/packages/require-a-lot/src/index.d.ts
+++ b/packages/require-a-lot/src/index.d.ts
@@ -1,0 +1,18 @@
+declare module 'require-a-lot' {
+  interface RALMethods {
+    (): object;
+    alias: (...aliases: string[]) => this;
+    from: (...packages: string[]) => this;
+    hide: (...packages: string[]) => this;
+    log: this;
+    info: this;
+    tag: (tag: string) => {
+      linkDirectory: (dir: string) => RALMethods;
+    };
+    removeUnused: this;
+    define: (name: string, newValue: any) => this;
+    compose: (newObjectName: string, fn: Function, packages: string | string[]) => this;
+  }
+
+  export default function requireALot(requireModuleInstance: NodeRequire): (...packages: string[]) => RALMethods;
+}


### PR DESCRIPTION
Resolves #104. I used each package's `/src` directory instead of `/dist/src` as `/dist` was listed in their respective `.gitignore` files. Let me know if there are any issues.